### PR TITLE
Add dark mode support to chat page

### DIFF
--- a/client/src/components/ChatPage/ChatWindow/ChatMessages.tsx
+++ b/client/src/components/ChatPage/ChatWindow/ChatMessages.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import type { RefObject } from "react";
 import ReactMarkdown from "react-markdown";
 import type { Components } from "react-markdown";
 import type { Message } from "../../../hooks/useChatMessages";
@@ -7,7 +7,7 @@ import ThinkingIndicator from "./ThinkingIndicator";
 
 interface ChatMessagesProps {
   messages: Message[];
-  messagesEndRef: React.RefObject<HTMLDivElement | null>;
+  messagesEndRef: RefObject<HTMLDivElement | null>;
 }
 
 const markdownComponents: Components = {
@@ -18,7 +18,7 @@ const markdownComponents: Components = {
   a: ({ href, children }) => (
     <a
       href={href}
-      className="text-blue-600 underline hover:text-blue-800"
+      className="text-blue-600 underline hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
       target="_blank"
       rel="noreferrer"
     >
@@ -38,7 +38,7 @@ const ChatMessages = ({ messages, messagesEndRef }: ChatMessagesProps) => (
           className={`flex flex-col gap-1.5 ${isUser ? "items-end" : "items-start"}`}
         >
           {isUser ? (
-            <div className="animate-slide-up max-w-[80%] md:max-w-sm rounded-2xl rounded-tr-sm bg-gray-100 px-4 py-3 text-sm leading-relaxed text-gray-800">
+            <div className="animate-slide-up max-w-[80%] md:max-w-sm rounded-2xl rounded-tr-sm bg-gray-100 px-4 py-3 text-sm leading-relaxed text-gray-800 dark:text-gray-200 dark-glass">
               {msg.text}
             </div>
           ) : msg.loading ? (
@@ -46,7 +46,7 @@ const ChatMessages = ({ messages, messagesEndRef }: ChatMessagesProps) => (
               <ThinkingIndicator />
             </div>
           ) : (
-            <div className="animate-slide-up max-w-xl text-sm leading-relaxed text-gray-800">
+            <div className="animate-slide-up max-w-xl text-sm leading-relaxed text-gray-800 dark:text-gray-200">
               <ReactMarkdown components={markdownComponents}>{msg.text}</ReactMarkdown>
             </div>
           )}

--- a/client/src/components/ChatPage/ChatWindow/ChatWindow.tsx
+++ b/client/src/components/ChatPage/ChatWindow/ChatWindow.tsx
@@ -7,6 +7,7 @@ import PreChatScreen from "./PreChatScreen";
 import ChatMessages from "./ChatMessages";
 import InputBox from "./InputBox";
 import FileUploadPopover from "./FileUploadPopover";
+import DegreeAuditModal from "./DegreeAuditModal";
 import FilePreview from "./FilePreview";
 import type { UploadedFile } from "./FileUploadPopover";
 
@@ -21,6 +22,7 @@ const ChatWindow = ({ onMenuClick, newChatSignal }: ChatWindowProps) => {
   const [hasSentFirstMessage, setHasSentFirstMessage] = useState(false);
   const [inputValue, setInputValue] = useState("");
   const [showUploadPopover, setShowUploadPopover] = useState(false);
+  const [showAuditGuide, setShowAuditGuide] = useState(false);
   const [uploadedFile, setUploadedFile] = useState<UploadedFile | null>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
@@ -72,21 +74,28 @@ const ChatWindow = ({ onMenuClick, newChatSignal }: ChatWindowProps) => {
   };
 
   return (
-    <div className="relative flex h-full w-full flex-col overflow-hidden bg-white">
+    <div className="relative flex h-full w-full flex-col overflow-hidden bg-white dark:bg-slate-950">
       {/* Hamburger button — mobile only */}
       <button
         onClick={onMenuClick}
         className="absolute top-4 left-4 z-20 flex flex-col gap-1 p-1 md:hidden"
         aria-label="Open menu"
       >
-        <span className="block h-0.5 w-5 bg-gray-600" />
-        <span className="block h-0.5 w-5 bg-gray-600" />
-        <span className="block h-0.5 w-5 bg-gray-600" />
+        <span className="block h-0.5 w-5 bg-gray-600 dark:bg-gray-300" />
+        <span className="block h-0.5 w-5 bg-gray-600 dark:bg-gray-300" />
+        <span className="block h-0.5 w-5 bg-gray-600 dark:bg-gray-300" />
       </button>
 
       {showUploadPopover && (
         <FileUploadPopover
           onClose={() => setShowUploadPopover(false)}
+          onFileSelect={(f) => setUploadedFile(f)}
+        />
+      )}
+
+      {showAuditGuide && (
+        <DegreeAuditModal
+          onClose={() => setShowAuditGuide(false)}
           onFileSelect={(f) => setUploadedFile(f)}
         />
       )}
@@ -99,6 +108,7 @@ const ChatWindow = ({ onMenuClick, newChatSignal }: ChatWindowProps) => {
           onSend={handleSend}
           onKeyDown={handleKeyDown}
           onAttachClick={() => setShowUploadPopover(true)}
+          onGuideClick={() => setShowAuditGuide(true)}
           uploadedFile={uploadedFile}
           onRemoveFile={() => setUploadedFile(null)}
         />

--- a/client/src/components/ChatPage/ChatWindow/DegreeAuditGuide.tsx
+++ b/client/src/components/ChatPage/ChatWindow/DegreeAuditGuide.tsx
@@ -1,0 +1,14 @@
+interface DegreeAuditGuideProps {
+  onClick: () => void;
+}
+
+const DegreeAuditGuide = ({ onClick }: DegreeAuditGuideProps) => (
+  <button
+    onClick={onClick}
+    className="speech-bubble group rounded-xl bg-white dark:bg-[#1a2535] px-4 py-2.5 text-sm font-medium text-app-blue dark:text-app-gold border border-gray-200 dark:border-[rgba(255,255,255,0.1)] shadow-sm transition-all hover:shadow-md cursor-pointer"
+  >
+    Need personalized help? Learn how!
+  </button>
+);
+
+export default DegreeAuditGuide;

--- a/client/src/components/ChatPage/ChatWindow/DegreeAuditModal.tsx
+++ b/client/src/components/ChatPage/ChatWindow/DegreeAuditModal.tsx
@@ -1,0 +1,93 @@
+import React, { useRef, useCallback } from "react";
+import CloseModalIcon from "../../../assets/icons/CloseModalIcon";
+import type { UploadedFile } from "./FileUploadPopover";
+
+const ACCEPTED = ["application/pdf", "image/png", "image/jpeg"];
+
+interface DegreeAuditModalProps {
+  onClose: () => void;
+  onFileSelect: (uploaded: UploadedFile) => void;
+}
+
+const DegreeAuditModal = ({ onClose, onFileSelect }: DegreeAuditModalProps) => {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const processFile = useCallback(
+    (file: File) => {
+      if (!ACCEPTED.includes(file.type)) return;
+      if (file.type.startsWith("image/")) {
+        const previewUrl = URL.createObjectURL(file);
+        onFileSelect({ file, previewUrl, fileType: "image" });
+      } else {
+        onFileSelect({ file, previewUrl: null, fileType: "audit" });
+      }
+      onClose();
+    },
+    [onFileSelect, onClose],
+  );
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) processFile(file);
+  };
+
+  return (
+    <div
+      className="absolute inset-0 z-50 flex items-center justify-center bg-black/30"
+      onClick={onClose}
+    >
+      <div
+        className="relative w-[90vw] max-w-[440px] rounded-2xl bg-white p-6 md:p-8 shadow-xl dark-glass"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <button
+          onClick={onClose}
+          className="absolute top-4 right-4 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 transition-colors cursor-pointer"
+          aria-label="Close"
+        >
+          <CloseModalIcon />
+        </button>
+
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+          Upload Your Degree Audit
+        </h2>
+        <p className="mt-1 text-sm text-gray-500 dark:text-slate-400">
+          Get personalized advising based on your academic progress
+        </p>
+
+        <ol className="mt-5 space-y-2 text-sm text-gray-700 dark:text-gray-300">
+          <li>
+            1. Go to{" "}
+            <a
+              href="https://my.fiu.edu"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-semibold text-app-gold hover:underline"
+            >
+              MyFIU
+            </a>
+          </li>
+          <li>2. Navigate to Academic Advising, then Degree Audit</li>
+          <li>3. Download your audit as a PDF</li>
+        </ol>
+
+        <button
+          onClick={() => inputRef.current?.click()}
+          className="mt-6 w-full rounded-xl bg-app-blue py-3 text-sm font-semibold text-white transition-colors hover:bg-app-blue/90 cursor-pointer"
+        >
+          Upload Degree Audit
+        </button>
+
+        <input
+          ref={inputRef}
+          type="file"
+          accept={ACCEPTED.join(",")}
+          className="hidden"
+          onChange={handleInputChange}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default DegreeAuditModal;

--- a/client/src/components/ChatPage/ChatWindow/FilePreview.tsx
+++ b/client/src/components/ChatPage/ChatWindow/FilePreview.tsx
@@ -8,7 +8,7 @@ interface FilePreviewProps {
 }
 
 const FilePreview = ({ uploadedFile, onRemove }: FilePreviewProps) => (
-  <div className="inline-flex items-center gap-2 rounded-xl border border-gray-200 bg-gray-50 px-3 py-2 text-xs text-gray-600 shadow-sm">
+  <div className="inline-flex items-center gap-2 rounded-xl border border-gray-200 bg-gray-50 px-3 py-2 text-xs text-gray-600 dark:text-gray-300 shadow-sm dark-glass">
     {uploadedFile.previewUrl ? (
       <img
         src={uploadedFile.previewUrl}
@@ -16,7 +16,7 @@ const FilePreview = ({ uploadedFile, onRemove }: FilePreviewProps) => (
         className="h-8 w-8 rounded object-cover"
       />
     ) : (
-      <div className="relative flex h-10 w-10 items-center justify-center rounded-lg bg-gray-100">
+      <div className="relative flex h-10 w-10 items-center justify-center rounded-lg bg-gray-100 dark:bg-slate-700">
         <FileIcon />
       </div>
     )}
@@ -24,7 +24,7 @@ const FilePreview = ({ uploadedFile, onRemove }: FilePreviewProps) => (
     {onRemove && (
       <button
         onClick={onRemove}
-        className="ml-1 text-gray-400 hover:text-gray-600 transition-colors"
+        className="ml-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 transition-colors"
         aria-label="Remove file"
       >
         <RemoveIcon />

--- a/client/src/components/ChatPage/ChatWindow/FileUploadPopover.tsx
+++ b/client/src/components/ChatPage/ChatWindow/FileUploadPopover.tsx
@@ -22,6 +22,7 @@ const FileUploadPopover = ({
 }: FileUploadPopoverProps) => {
   const inputRef = useRef<HTMLInputElement>(null);
   const [selectedType, setSelectedType] = useState<"audit" | "document">("audit");
+  const [showGuide, setShowGuide] = useState(false);
 
   const processFile = useCallback(
   (file: File) => {
@@ -61,67 +62,116 @@ const FileUploadPopover = ({
       onClick={onClose}
     >
       <div
-        className="relative w-[90vw] max-w-[480px] rounded-2xl bg-white p-6 md:p-8 shadow-xl"
+        className="relative w-[90vw] max-w-[480px] rounded-2xl bg-white p-6 md:p-8 shadow-xl dark-glass"
         onClick={(e) => e.stopPropagation()}
       >
         <button
           onClick={onClose}
-          className="absolute top-4 right-4 text-gray-400 hover:text-gray-600 transition-colors"
+          className="absolute top-4 right-4 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 transition-colors cursor-pointer"
           aria-label="Close"
         >
           <CloseModalIcon />
         </button>
 
-        <h2 className="mb-5 text-xl font-semibold text-gray-900">
-          File Upload
-        </h2>
+        {showGuide ? (
+          <>
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+              Upload Your Degree Audit
+            </h2>
+            <p className="mt-1 text-sm text-gray-500 dark:text-slate-400">
+              Get personalized advising based on your academic progress
+            </p>
+            <ol className="mt-5 space-y-2 text-sm text-gray-700 dark:text-gray-300">
+              <li>
+                1. Go to{" "}
+                <a
+                  href="https://my.fiu.edu"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="font-semibold text-app-gold hover:underline"
+                >
+                  MyFIU
+                </a>
+              </li>
+              <li>2. Navigate to Academic Advising, then Degree Audit</li>
+              <li>3. Download your audit as a PDF</li>
+            </ol>
+            <button
+              onClick={() => {
+                setShowGuide(false);
+                inputRef.current?.click();
+              }}
+              className="mt-6 w-full rounded-xl bg-app-blue py-3 text-sm font-semibold text-white transition-colors hover:bg-app-blue/90 cursor-pointer"
+            >
+              Upload Degree Audit
+            </button>
+          </>
+        ) : (
+          <>
+            <h2 className="mb-5 text-xl font-semibold text-gray-900 dark:text-white">
+              File Upload
+            </h2>
 
-        <div className="mb-5 flex gap-6">
-          <label className="flex items-center gap-2 cursor-pointer">
-            <input
-              type="radio"
-              name="fileType"
-              value="audit"
-              checked={selectedType === "audit"}
-              onChange={() => setSelectedType("audit")}
-              className="accent-app-blue"
-            />
-            <span className="text-sm text-gray-700">Degree Audit</span>
-          </label>
-          <label className="flex items-center gap-2 cursor-pointer">
-            <input
-              type="radio"
-              name="fileType"
-              value="document"
-              checked={selectedType === "document"}
-              onChange={() => setSelectedType("document")}
-              className="accent-app-blue"
-            />
-            <span className="text-sm text-gray-700">Other Document</span>
-          </label>
-        </div>
+            <div className="mb-5 flex gap-6">
+              <label className="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="radio"
+                  name="fileType"
+                  value="audit"
+                  checked={selectedType === "audit"}
+                  onChange={() => setSelectedType("audit")}
+                  className="accent-app-blue"
+                />
+                <span className="text-sm text-gray-700 dark:text-gray-300">Degree Audit</span>
+              </label>
+              <label className="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="radio"
+                  name="fileType"
+                  value="document"
+                  checked={selectedType === "document"}
+                  onChange={() => setSelectedType("document")}
+                  className="accent-app-blue"
+                />
+                <span className="text-sm text-gray-700 dark:text-gray-300">Other Document</span>
+              </label>
+            </div>
 
-        <div
-          className="flex cursor-pointer flex-col items-center justify-center gap-3 rounded-xl border-2 border-dashed border-gray-200 bg-gray-50 py-14 transition-colors hover:bg-gray-100"
-          onDrop={handleDrop}
-          onDragOver={handleDragOver}
-          onClick={() => inputRef.current?.click()}
-        >
-          <UploadImageIcon />
-          <span className="text-sm font-medium text-gray-400">
-            Drag and drop or click here
-          </span>
-        </div>
+            <div
+              className="flex cursor-pointer flex-col items-center justify-center gap-3 rounded-xl border-2 border-dashed border-gray-200 dark:border-slate-600 bg-gray-50 dark:bg-slate-800 py-14 transition-colors hover:bg-gray-100 dark:hover:bg-slate-700"
+              onDrop={handleDrop}
+              onDragOver={handleDragOver}
+              onClick={() => inputRef.current?.click()}
+            >
+              <UploadImageIcon />
+              <span className="text-sm font-medium text-gray-400 dark:text-slate-400">
+                Drag and drop or click here
+              </span>
+            </div>
 
-        <p className="mt-4 text-center text-xs text-gray-400">
-          Accepted file types:{" "}
-          {ACCEPTED_LABEL.split(", ").map((t, i) => (
-            <span key={t}>
-              {i > 0 && ", "}
-              <span className="text-blue-500">{t}</span>
-            </span>
-          ))}
-        </p>
+            <p className="mt-4 text-center text-xs text-gray-400 dark:text-slate-400">
+              Accepted file types:{" "}
+              {ACCEPTED_LABEL.split(", ").map((t, i) => (
+                <span key={t}>
+                  {i > 0 && ", "}
+                  <span className="text-blue-500 dark:text-blue-400">{t}</span>
+                </span>
+              ))}
+            </p>
+
+            {selectedType === "audit" && (
+              <p className="mt-4 text-center text-xs text-gray-400 dark:text-slate-400">
+                Don't have your audit yet?{" "}
+                <button
+                  onClick={() => setShowGuide(true)}
+                  className="font-medium text-app-blue dark:text-app-gold hover:underline cursor-pointer"
+                >
+                  Need personalized help? Learn how!
+                </button>
+              </p>
+            )}
+          </>
+        )}
 
         <input
           ref={inputRef}

--- a/client/src/components/ChatPage/ChatWindow/InputBox.tsx
+++ b/client/src/components/ChatPage/ChatWindow/InputBox.tsx
@@ -1,11 +1,11 @@
-import React from "react";
+import type { KeyboardEvent } from "react";
 import AttachmentIcon from "../../../assets/icons/AttachmentIcon";
 import SendIcon from "../../../assets/icons/SendIcon";
 
-export interface InputBoxProps {
+interface InputBoxProps {
   value: string;
   onChange: (v: string) => void;
-  onKeyDown: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void;
+  onKeyDown: (e: KeyboardEvent<HTMLTextAreaElement>) => void;
   onSend: () => void;
   placeholder: string;
   onAttachClick: () => void;
@@ -19,9 +19,9 @@ const InputBox = ({
   placeholder,
   onAttachClick,
 }: InputBoxProps) => (
-  <div className="relative w-full rounded-2xl border border-gray-200 bg-white px-4 pt-3 pb-12 shadow-sm">
+  <div className="relative w-full rounded-2xl border border-gray-200 bg-white px-4 pt-3 pb-12 shadow-sm dark-glass">
     <textarea
-      className="w-full resize-none bg-transparent text-sm leading-relaxed text-gray-700 placeholder-gray-300 outline-none no-scrollbar"
+      className="w-full resize-none bg-transparent text-sm leading-relaxed text-gray-700 dark:text-gray-200 placeholder-gray-300 dark:placeholder-slate-500 outline-none no-scrollbar"
       rows={2}
       placeholder={placeholder}
       value={value}
@@ -32,7 +32,7 @@ const InputBox = ({
     <div className="absolute right-3 bottom-3 flex items-center gap-2">
       <button
         onClick={onAttachClick}
-        className="p-1 transition-colors text-app-blue hover:text-gray-600"
+        className="p-1 transition-colors text-app-blue dark:text-gray-200 hover:text-gray-600 dark:hover:text-white"
         aria-label="Attach file"
       >
         <AttachmentIcon />
@@ -41,7 +41,7 @@ const InputBox = ({
       <button
         onClick={onSend}
         disabled={!value.trim()}
-        className="flex bg-app-blue rounded-xl p-2 text-white transition-all hover:opacity-90 cursor-pointer disabled:opacity-40 justify-center items-center"
+        className="flex bg-app-blue dark:bg-app-gold rounded-xl p-2 text-white transition-colors hover:opacity-90 cursor-pointer disabled:opacity-40 justify-center items-center"
         aria-label="Send"
       >
         <SendIcon />

--- a/client/src/components/ChatPage/ChatWindow/PreChatScreen.tsx
+++ b/client/src/components/ChatPage/ChatWindow/PreChatScreen.tsx
@@ -1,6 +1,7 @@
-import React from "react";
+import type { KeyboardEvent } from "react";
 import InputBox from "./InputBox";
 import FilePreview from "./FilePreview";
+import DegreeAuditGuide from "./DegreeAuditGuide";
 import type { UploadedFile } from "./FileUploadPopover";
 
 interface PreChatScreenProps {
@@ -8,8 +9,9 @@ interface PreChatScreenProps {
   inputValue: string;
   setInputValue: (v: string) => void;
   onSend: () => void;
-  onKeyDown: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void;
+  onKeyDown: (e: KeyboardEvent<HTMLTextAreaElement>) => void;
   onAttachClick: () => void;
+  onGuideClick: () => void;
   uploadedFile?: UploadedFile | null;
   onRemoveFile?: () => void;
 }
@@ -21,32 +23,40 @@ const PreChatScreen = ({
   onSend,
   onKeyDown,
   onAttachClick,
+  onGuideClick,
   uploadedFile,
   onRemoveFile,
 }: PreChatScreenProps) => (
-  <div className="flex h-full flex-col items-center justify-center gap-10 px-8 pt-14 md:pt-0">
+  <div className="relative flex h-full flex-col items-center justify-center gap-10 px-8 pt-14 md:pt-0">
     <div className="font-instrument flex flex-wrap items-baseline justify-center gap-2 select-none text-center">
-      <h1 className="text-app-blue text-4xl md:text-6xl font-normal">Need Info on</h1>
+      <h1 className="text-app-blue dark:text-white text-4xl md:text-6xl font-normal">Need Info on</h1>
       <span className="text-app-gold inline-block text-4xl md:text-6xl font-normal">
         <p>{currentWord}?</p>
       </span>
     </div>
 
     <div className="w-full max-w-xl">
-      <InputBox
-        value={inputValue}
-        onChange={setInputValue}
-        onKeyDown={onKeyDown}
-        onSend={onSend}
-        placeholder="What advising questions do you have?"
-        onAttachClick={onAttachClick}
-      />
-
-      {uploadedFile && onRemoveFile && (
-        <div className="mt-3 flex">
-          <FilePreview uploadedFile={uploadedFile} onRemove={onRemoveFile} />
-        </div>
-      )}
+      <div className="relative">
+        <InputBox
+          value={inputValue}
+          onChange={setInputValue}
+          onKeyDown={onKeyDown}
+          onSend={onSend}
+          placeholder="What advising questions do you have?"
+          onAttachClick={onAttachClick}
+        />
+        {/* Bubble below the input box — hidden once a degree audit is uploaded */}
+        {uploadedFile?.fileType !== "audit" && (
+          <div className="absolute top-full mt-2 right-[33px]">
+            <DegreeAuditGuide onClick={onGuideClick} />
+          </div>
+        )}
+        {uploadedFile && onRemoveFile && (
+          <div className="absolute top-full mt-2 left-0">
+            <FilePreview uploadedFile={uploadedFile} onRemove={onRemoveFile} />
+          </div>
+        )}
+      </div>
     </div>
   </div>
 );

--- a/client/src/components/ChatPage/ChatWindow/ThinkingIndicator.tsx
+++ b/client/src/components/ChatPage/ChatWindow/ThinkingIndicator.tsx
@@ -7,9 +7,9 @@ const ThinkingIndicator = () => (
       {bars.map((bar, i) => (
         <div
           key={i}
-          className={`${bar.width} h-3 rounded-full bg-gray-200 overflow-hidden`}
+          className={`${bar.width} h-3 rounded-full bg-gray-200 dark:bg-slate-800 overflow-hidden`}
         >
-          <div className="h-full w-full animate-shimmer rounded-full bg-linear-to-r from-gray-200 via-gray-100 to-gray-200 bg-size-[200%_100%]" />
+          <div className="h-full w-full animate-shimmer rounded-full bg-linear-to-r from-gray-200 via-gray-100 to-gray-200 dark:from-slate-800 dark:via-slate-700 dark:to-slate-800 bg-size-[200%_100%]" />
         </div>
       ))}
     </div>

--- a/client/src/components/ChatPage/Sidebar/SidebarLink.tsx
+++ b/client/src/components/ChatPage/Sidebar/SidebarLink.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import arrow_link from "../../../assets/external_link_arrow.png";
 
 interface SidebarLinkProps {
@@ -6,7 +5,7 @@ interface SidebarLinkProps {
   text: string;
 }
 
-const SidebarLink: React.FC<SidebarLinkProps> = ({ link, text }) => {
+const SidebarLink = ({ link, text }: SidebarLinkProps) => {
   return (
     <div>
       <a

--- a/client/src/components/ChatPage/Sidebar/SidebarSection.tsx
+++ b/client/src/components/ChatPage/Sidebar/SidebarSection.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import SidebarLink from "./SidebarLink";
 
 interface SidebarSectionProps {
@@ -9,7 +8,7 @@ interface SidebarSectionProps {
   }[];
 }
 
-const SidebarSection: React.FC<SidebarSectionProps> = ({ title, links }) => {
+const SidebarSection = ({ title, links }: SidebarSectionProps) => {
   return (
     <div className="flex w-full flex-col gap-3">
       <h2 className="text-app-yellow text-md font-bold underline">{title}</h2>

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -9,6 +9,7 @@
 
 html, body {
   background-color: #000;
+  color-scheme: light dark;
 }
 
 .liquid-glass {
@@ -32,6 +33,50 @@ html, body {
     0 0 25px rgba(182, 134, 44, 0.35),
     0 0 50px rgba(182, 134, 44, 0.15);
   transform: scale(1.03);
+}
+
+@media (prefers-color-scheme: dark) {
+  .dark-glass {
+    background: linear-gradient(
+      135deg,
+      rgba(255, 255, 255, 0.08) 0%,
+      rgba(255, 255, 255, 0.03) 40%,
+      rgba(255, 255, 255, 0.06) 100%
+    );
+    backdrop-filter: blur(24px) saturate(180%) brightness(1.1);
+    -webkit-backdrop-filter: blur(24px) saturate(180%) brightness(1.1);
+    border-color: rgba(255, 255, 255, 0.08);
+    box-shadow:
+      0 1px 0 0 rgba(255, 255, 255, 0.05) inset,
+      0 4px 30px rgba(0, 0, 0, 0.15);
+  }
+}
+
+
+/* Speech-bubble tail — uses the same glass surface as the parent */
+.speech-bubble {
+  position: relative;
+  overflow: visible;
+}
+
+.speech-bubble::before {
+  content: "";
+  position: absolute;
+  top: -6px;
+  right: 22px;
+  width: 12px;
+  height: 12px;
+  transform: rotate(45deg);
+  background: white;
+  border-left: 1px solid #e5e7eb;
+  border-top: 1px solid #e5e7eb;
+}
+
+@media (prefers-color-scheme: dark) {
+  .speech-bubble::before {
+    background: #1a2535;
+    border-color: rgba(255, 255, 255, 0.1);
+  }
 }
 
 .no-scrollbar {

--- a/client/src/pages/ChatPage.tsx
+++ b/client/src/pages/ChatPage.tsx
@@ -1,4 +1,3 @@
-import "../index.css";
 import { useState } from "react";
 
 import Sidebar from "../components/ChatPage/Sidebar/Sidebar";


### PR DESCRIPTION
## Summary
- Added dark mode support across all chat page components (ChatWindow, ChatMessages, InputBox, FilePreview, FileUploadPopover, ThinkingIndicator, Sidebar)
- Added `dark-glass` CSS effect and speech-bubble styling for dark theme
- Added DegreeAuditGuide bubble and DegreeAuditModal for guiding users to upload their degree audit
- Cleaned up redundant imports and unused code in chat page files

## Test plan
- [ ] Verify dark mode renders correctly across all chat page components
- [ ] Test degree audit guide bubble appears on pre-chat screen
- [ ] Test degree audit modal opens and allows file upload
- [ ] Confirm light mode is unaffected
- [ ] Verify build passes with no errors